### PR TITLE
Feature/#8

### DIFF
--- a/.github/workflows/mobile-app-test.yml
+++ b/.github/workflows/mobile-app-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run ls-lint
-        uses: ls-lint/action@v2
+        run: npm run ls-lint
       - name: Run ESLint
         run: npm run lint
       - name: Run Prettier

--- a/.github/workflows/mobile-app-test.yml
+++ b/.github/workflows/mobile-app-test.yml
@@ -24,6 +24,8 @@ jobs:
           node-version-file: mobile-app/.nvmrc
       - name: Install dependencies
         run: npm ci
+      - name: Run ls-lint
+        uses: ls-lint/action@v2
       - name: Run ESLint
         run: npm run lint
       - name: Run Prettier

--- a/.github/workflows/mobile-app-test.yml
+++ b/.github/workflows/mobile-app-test.yml
@@ -33,6 +33,7 @@ jobs:
           config: ${{ env.WORKING_DIRECTORY }}/.ls-lint.yml
           workdir: ${{ env.WORKING_DIRECTORY }}
           debug: true
+          warn: false
       - name: Run ESLint
         run: npm run lint
       - name: Run Prettier

--- a/.github/workflows/mobile-app-test.yml
+++ b/.github/workflows/mobile-app-test.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           config: ${{ env.WORKING_DIRECTORY }}/.ls-lint.yml
           workdir: ${{ env.WORKING_DIRECTORY }}
-          warn: true
           debug: true
       - name: Run ESLint
         run: npm run lint

--- a/.github/workflows/mobile-app-test.yml
+++ b/.github/workflows/mobile-app-test.yml
@@ -9,13 +9,16 @@ on:
       - .github/workflows/test.yml
       - mobile-app/**
 
+env:
+  WORKING_DIRECTORY: mobile-app
+
 jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: mobile-app
+        working-directory: ${{ env.WORKING_DIRECTORY }}
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Use Node.js
@@ -25,7 +28,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run ls-lint
-        run: npm run ls-lint
+        uses: ls-lint/action@v2
+        with:
+          workdir: ${{ env.WORKING_DIRECTORY }}
+          warn: true
+          debug: true
       - name: Run ESLint
         run: npm run lint
       - name: Run Prettier

--- a/.github/workflows/mobile-app-test.yml
+++ b/.github/workflows/mobile-app-test.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Run ls-lint
         uses: ls-lint/action@v2
         with:
+          config: ${{ env.WORKING_DIRECTORY }}/.ls-lint.yml
           workdir: ${{ env.WORKING_DIRECTORY }}
           warn: true
           debug: true

--- a/mobile-app/.ls-lint.yml
+++ b/mobile-app/.ls-lint.yml
@@ -1,0 +1,24 @@
+ls:
+  dir: kebab-case
+  .js: kebab-case
+  .ts: kebab-case
+  .png: kebab-case
+  .jpg: kebab-case
+  .jpeg: kebab-case
+  .svg: kebab-case
+  app:
+    .tsx: kebab-case
+  components:
+    .tsx: PascalCase
+  constants:
+    .ts: PascalCase
+  hooks:
+    .ts: camelCase
+
+ignore:
+  - node_modules
+  - .vscode
+  - app/**/_layout.tsx
+  - app/**/+not-found.tsx
+  - assets/images/**/[!@]*@2x.*
+  - assets/images/**/[!@]*@3x.*

--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -37,6 +37,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
+        "@ls-lint/ls-lint": "^2.3.1",
         "@types/react": "~19.0.10",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~9.2.0",
@@ -2643,6 +2644,27 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@ls-lint/ls-lint": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@ls-lint/ls-lint/-/ls-lint-2.3.1.tgz",
+      "integrity": "sha512-vPe6IDByQnQRTxcAYjTxrmga/tSIui50VBFTB5KIJWY3OOFmxE2VtymjeSEfQfiMbhZV/ZPAqYy2lt8pZFQ0Rw==",
+      "cpu": [
+        "x64",
+        "arm64",
+        "s390x",
+        "ppc64le"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "bin": {
+        "ls-lint": "bin/cli.js"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -13,7 +13,8 @@
     "web": "expo start --web",
     "lint": "expo lint",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "ls-lint": "npx ls-lint"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
@@ -45,6 +46,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
+    "@ls-lint/ls-lint": "^2.3.1",
     "@types/react": "~19.0.10",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -14,7 +14,7 @@
     "lint": "expo lint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "ls-lint": "npx ls-lint"
+    "ls-lint": "npx ls-lint -warn -debug"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -14,7 +14,7 @@
     "lint": "expo lint",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "ls-lint": "npx ls-lint -warn -debug"
+    "ls-lint": "npx ls-lint -debug"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",


### PR DESCRIPTION
This pull request introduces `ls-lint` to enforce consistent naming conventions across the `mobile-app` project. The most important changes include adding `ls-lint` configuration, integrating it into the CI workflow, and updating dependencies to include `ls-lint`.

### Integration of `ls-lint`:

* [`.github/workflows/mobile-app-test.yml`](diffhunk://#diff-684ee5fe0bb1411145cd1c9ce3fec768cda6e117ec5e8ddceae190b6c951a5a3R27-R28): Added a step to run `ls-lint` in the CI workflow.
* [`mobile-app/.ls-lint.yml`](diffhunk://#diff-cc23bce5dea97edd44baeff4f772c1afb04345454aaa7a8baa36572d2bc46f01R1-R24): Created a configuration file specifying naming conventions for various file types and directories, along with ignored paths.

### Dependency Updates:

* [`mobile-app/package-lock.json`](diffhunk://#diff-2cb6685943a15ef68ee22a7a656af6d406c38a3de0172394d22f9c05871201e6R40): Added `@ls-lint/ls-lint` as a development dependency with details about its version, integrity, and supported platforms. [[1]](diffhunk://#diff-2cb6685943a15ef68ee22a7a656af6d406c38a3de0172394d22f9c05871201e6R40) [[2]](diffhunk://#diff-2cb6685943a15ef68ee22a7a656af6d406c38a3de0172394d22f9c05871201e6R2649-R2669)
* [`mobile-app/package.json`](diffhunk://#diff-18947c7198f317ecc517065caaf1d5ec6277a74918e95cdb24035bdca958fbdcL16-R17): Added `@ls-lint/ls-lint` to `devDependencies` and introduced a new script `"ls-lint": "npx ls-lint"` for running `ls-lint` locally. [[1]](diffhunk://#diff-18947c7198f317ecc517065caaf1d5ec6277a74918e95cdb24035bdca958fbdcL16-R17) [[2]](diffhunk://#diff-18947c7198f317ecc517065caaf1d5ec6277a74918e95cdb24035bdca958fbdcR49)

close #8 